### PR TITLE
Increase Footer Link Contrast

### DIFF
--- a/assets/css/styleguide.css
+++ b/assets/css/styleguide.css
@@ -1652,7 +1652,7 @@ dfn {
   .usa-background-dark span {
     color: #ffffff; }
   .usa-background-dark a {
-    color: #d6d7d9; }
+    color: #981b1e; }
     .usa-background-dark a:hover {
       color: #ffffff; }
 


### PR DESCRIPTION
I'm not 100% if `styleguide.css` is the right place to change this, but it worked correctly on my localhost:4000 test

