### PR TITLE
Hide phase disclaimer for production

### DIFF
--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -7,7 +7,9 @@
       <img class="usa-flag_icon" alt="usa flag icon" src="{{ site.baseurl }}/assets/img/us_flag_small.png">
       {{ site.banner }}
     </span>
+    {% if site.phase != 'Production' %}
     <span class="usa-disclaimer-stage">This site is currently in {{ site.phase }}</span>
+    {% endif %}
   </div>
 
   <nav class="usa-hero-navbar">


### PR DESCRIPTION
Production should be the default phase where no disclaimer is necessary. Most users would never even know there are other phases than production.

