### PR TITLE
Use published version of uswds-jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'go_script'
 gem 'guides_style_18f'
 gem 'jekyll'
 gem 'rouge'
-gem 'uswds-jekyll', git: 'https://github.com/18F/uswds-jekyll'
+gem 'uswds-jekyll'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/18F/uswds-jekyll
-  revision: 413413405c01ffbbb039ab7bd38767db9ab87484
-  specs:
-    uswds-jekyll (4.2.0)
-      jekyll (>= 3.4, < 5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -71,6 +64,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    uswds-jekyll (4.2.0)
+      jekyll (~> 3.4)
 
 PLATFORMS
   ruby
@@ -80,7 +75,7 @@ DEPENDENCIES
   guides_style_18f
   jekyll
   rouge
-  uswds-jekyll!
+  uswds-jekyll
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
Use a published version of uswds-jekyll instead of the master branch which no
longer exists.
